### PR TITLE
Change cache_url to redis_url

### DIFF
--- a/{{cookiecutter.project_dirname}}/terraform/environment/digitalocean-k8s/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/environment/digitalocean-k8s/main.tf
@@ -236,15 +236,15 @@ resource "kubernetes_secret_v1" "database_url" {
   }
 }
 
-resource "kubernetes_secret_v1" "cache_url" {
+resource "kubernetes_secret_v1" "redis_url" {
   count = var.use_redis ? 1 : 0
 
   metadata {
-    name      = "cache-url"
+    name      = "redis-url"
     namespace = local.namespace
   }
   data = {
-    CACHE_URL = "${data.digitalocean_database_cluster.redis[0].private_uri}?key_prefix=${var.env_slug}"
+    REDIS_URL = data.digitalocean_database_cluster.redis[0].private_uri
   }
 }
 

--- a/{{cookiecutter.project_dirname}}/terraform/environment/modules/kubernetes/redis/outputs.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/environment/modules/kubernetes/redis/outputs.tf
@@ -1,5 +1,5 @@
-output "cache_url" {
-  description = "The Redis cache url."
+output "redis_url" {
+  description = "The Redis server URL."
   value       = "redis://:${random_password.main.result}@${kubernetes_service_v1.main.metadata[0].name}:6379"
   sensitive   = true
 }

--- a/{{cookiecutter.project_dirname}}/terraform/environment/other-k8s/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/environment/other-k8s/main.tf
@@ -170,15 +170,15 @@ resource "kubernetes_secret_v1" "database_url" {
   }
 }
 
-resource "kubernetes_secret_v1" "cache_url" {
+resource "kubernetes_secret_v1" "redis_url" {
   count = var.use_redis ? 1 : 0
 
   metadata {
-    name      = "cache-url"
+    name      = "redis-url"
     namespace = local.namespace
   }
   data = {
-    CACHE_URL = "${module.redis[0].cache_url}?key_prefix=${var.env_slug}"
+    REDIS_URL = module.redis[0].redis_url
   }
 }
 


### PR DESCRIPTION
The current secret holds the `CACHE_URL` value, as expected by the `django-cache-url` package. This prevents other potential components (e.g. Celery) to access the Redis server URL, which is contained in the `CACHE_URL` value but can not easily be used as-is. Therefore I suggest storing a `REDIS_URL` value with the Redis server URL, and then populate the `CACHE_URL` environment variable from it in the Django deployment, as proposed in the [twin PR](https://github.com/20tab/django-continuous-delivery/pull/279) in the Django-Talos subrepo.