### PR TITLE
Upgrade grafana version

### DIFF
--- a/{{cookiecutter.project_dirname}}/terraform/environment/digitalocean-k8s/variables.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/environment/digitalocean-k8s/variables.tf
@@ -128,7 +128,7 @@ variable "grafana_user" {
 variable "grafana_version" {
   description = "The Grafana version."
   type        = string
-  default     = "9.1.3"
+  default     = "9.4.1"
 }
 
 variable "letsencrypt_certificate_email" {

--- a/{{cookiecutter.project_dirname}}/terraform/environment/other-k8s/variables.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/environment/other-k8s/variables.tf
@@ -98,7 +98,7 @@ variable "grafana_user" {
 variable "grafana_version" {
   description = "The Grafana version."
   type        = string
-  default     = "9.1.3"
+  default     = "9.4.1"
 }
 
 variable "kubernetes_cluster_ca_certificate" {

--- a/{{cookiecutter.project_dirname}}/terraform/environment/vars/{% if "environment_prod" in cookiecutter.tfvars %}prod.tfvars{% endif %}
+++ b/{{cookiecutter.project_dirname}}/terraform/environment/vars/{% if "environment_prod" in cookiecutter.tfvars %}prod.tfvars{% endif %}
@@ -1,3 +1,3 @@
 {% for item in cookiecutter.tfvars.environment_prod|sort %}{{ item }}
 {% endfor %}# grafana_user="admin"
-# grafana_version="9.1.3"
+# grafana_version="9.4.1"


### PR DESCRIPTION
Upgrade grafana version with security fixes 
https://grafana.com/blog/2023/02/28/grafana-security-release-new-versions-with-security-fixes-for-cve-2023-0594-cve-2023-0507-and-cve-2023-22462/?mdm=social