### PR TITLE
Set up traefik explicit version

### DIFF
--- a/{{cookiecutter.project_dirname}}/terraform/cluster/modules/kubernetes/traefik/main.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/cluster/modules/kubernetes/traefik/main.tf
@@ -16,8 +16,9 @@ resource "helm_release" "traefik" {
   chart            = "traefik"
   namespace        = "traefik"
   create_namespace = true
-  repository       = "https://helm.traefik.io/traefik"
+  repository       = "https://traefik.github.io/charts"
   timeout          = 900
+  version          = var.traefik_helm_chart_version
 
   values = [
     file("${path.module}/values.yaml"),
@@ -43,7 +44,7 @@ resource "helm_release" "cert_manager" {
   namespace        = "cert-manager"
   create_namespace = true
   repository       = "https://charts.jetstack.io"
-  version          = "1.7.2"
+  version          = "1.14.4"
 
   set {
     name  = "installCRDs"

--- a/{{cookiecutter.project_dirname}}/terraform/cluster/modules/kubernetes/traefik/variables.tf
+++ b/{{cookiecutter.project_dirname}}/terraform/cluster/modules/kubernetes/traefik/variables.tf
@@ -9,3 +9,9 @@ variable "load_balancer_annotations" {
   type        = map(string)
   default     = {}
 }
+
+variable "traefik_helm_chart_version" {
+  description = "The helm chart Traefik version https://github.com/traefik/traefik-helm-chart/releases."
+  type        = string
+  default     = "26.0.0"
+}


### PR DESCRIPTION
Add explicit default traefik helm chart version to 26.0.0 (traefik v.2.10)
Change helm chart repo to https://traefik.github.io/charts
Upgrade cert-manager to 1.14.4